### PR TITLE
fix(ui): resolve process panel process buttons clipping issue

### DIFF
--- a/src/com/ossim/ui/panels/ProcessPanel.java
+++ b/src/com/ossim/ui/panels/ProcessPanel.java
@@ -151,13 +151,13 @@ public class ProcessPanel extends JPanel {
 
         JButton addT = UIUtils.makeButton("+ Thread", Theme.BORDER2, Theme.TEXT);
         addT.setFont(Theme.LABEL_SM);
-        addT.setPreferredSize(new Dimension(78, 24));
+        addT.setPreferredSize(new Dimension(95, 24));
         addT.addActionListener(e -> { if (listener != null) listener.onAddThread(proc.getPid()); });
         actions.add(addT);
 
         JButton term = UIUtils.makeButton("Kill", Theme.RED, Theme.RED);
         term.setFont(Theme.LABEL_SM);
-        term.setPreferredSize(new Dimension(56, 24));
+        term.setPreferredSize(new Dimension(60, 24));
         term.addActionListener(e -> { if (listener != null) listener.onTerminate(proc.getPid()); });
         actions.add(term);
 


### PR DESCRIPTION
### Summary
Fixes UI clipping issue in process panel buttons where "+ Thread" and "Kill" were rendering as "..." due to insufficient button sizing.

### Changes
- Increased button width to resolved the text clipping `...`


### Before
<img width="254" height="546" alt="image" src="https://github.com/user-attachments/assets/ee0b93bb-0af9-4162-92d7-c6b69569564e" />


## After
<img width="254" height="546" alt="image" src="https://github.com/user-attachments/assets/8c73f18d-df4f-4b14-866d-82fcd8cdd036" />


## Issue
Closes #12 