### PR TITLE
fix: correct typo 'Repesents' to 'Represents' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A professional simulation environment for Operating System CPU scheduling, synch
 
 Unlike many modern Java projects, this simulator was built with a **Strict Zero-Dependency** philosophy.
 
-- **No Maven / No Gradle**: We consciously avoided these tools to ensure the project stays lightweight and portable. Using Maven would introduce a large overhead of hidden scripts and a "wait-to-download" cycle. 
+- **No Maven / No Gradle**: We consciously avoided these tools to ensure the project stays lightweight and portable. Using Maven would introduce a large overhead of hidden scripts and a "wait-to-download" cycle.
 - **Raw Control**: By writing our own build scripts, we maintain 100% control over the compilation process and classpaths.
 - **Portability**: The project can be compiled and run on any machine with a standard JDK installed, without needing to resolve external dependencies or configure complex environments.
 - **Open Source**: We have fully **Open Sourced** this project to encourage learning and collaboration. You can find the source, modify it, and study the kernel logic without restriction.
@@ -18,23 +18,28 @@ Unlike many modern Java projects, this simulator was built with a **Strict Zero-
 ## CORE FEATURES
 
 ### Multicore Hardware Simulation
+
 - **Adjustable Cores**: Simulate between **1 and 16 CPU cores**.
 - **Real-Time Execution**: Each core features a dynamic progress bar showing the remaining burst time for the currently assigned thread.
 - **Per-Thread Colors**: Threads are assigned unique colors, making it easy to track them across the cores and the Gantt chart.
 
 ### Comprehensive Data Tables
+
 The simulator provides four distinct views into the system state:
+
 - **Thread Details**: Shows the raw data: PID, TID, active Algorithm, Burst Time, Time Quantum, Priority, and Memory footprint (MB).
 - **Timing Statistics**: Tracks real-time performance metrics: Arrival Time, Wait Time, Total Turnaround Time, and the exact clock tick when a thread finishes.
 - **Thread Status**: A live view of where each thread is (Ready, Running, Waiting, or Done), highlighting its current Core and Kernel Thread mapping.
 - **Kernel Thread Map**: Visualizes the relationship between User Threads and Kernel Threads based on the selected Thread Model (1:1, M:1, or M:M).
 
 ### Synchronization & Control
+
 - **Dual Sync Models**: Toggle between **Semaphores** and **Monitors**.
 - **Visual Blocking**: Threads are visibly blocked (turning yellow) when trying to acquire a held lock.
 - **Lock Dashboard**: Shows which thread holds the lock and the queue of threads waiting to enter.
 
 ### Gantt Chart & Movement Bar
+
 - **Historical Timeline**: A persistent Gantt chart records every execution slice, allowing for post-simulation analysis.
 - **Event Feed**: The "Thread Movement" bar provides a human-readable stream of events (e.g., "P1-T1: Ready -> Core 2").
 
@@ -44,10 +49,10 @@ The simulator provides four distinct views into the system state:
 
 Below is a short guide to every file in the repository and its role in the system:
 
-| File Path | Description |
-|---|---|
-| `src/com/ossim/Main.java` | The application entry point; initializes the UI and core engine. |
-| `src/com/ossim/model/KernelThread.java` | Repesents a kernel-level thread object used in thread mapping models. |
+| File Path                               | Description                                                            |
+| --------------------------------------- | ---------------------------------------------------------------------- |
+| `src/com/ossim/Main.java`               | The application entry point; initializes the UI and core engine.       |
+| `src/com/ossim/model/KernelThread.java` | Represents a kernel-level thread object used in thread mapping models. |
 
 | `src/com/ossim/model/MoveEvent.java` | A data structure for tracking thread state transitions (used for UI animations). |
 
@@ -92,23 +97,27 @@ Below is a short guide to every file in the repository and its role in the syste
 ## USER MANUAL & USAGE
 
 ### 1. Build and Run
+
 - **Windows**: Use the professional **RTOS_ThreadVision_Installer.exe** (created via jpackage) for a full installation.
-- **Linux / macOS**: 
+- **Linux / macOS**:
   - Ensure Java is installed.
   - You can simply **double-click the OSThreadSim.jar** file to launch the app.
   - Alternatively, use the terminal: `bash run.sh`.
 
 ### 2. Configuring the Simulation
+
 - **Top Bar**: Use this to swap between **FCFS**, **Round Robin**, **SJF**, and **Priority** on the fly.
 - **Thread Models**: Toggle between **1:1**, **Many-to-One**, and **Many-to-Many**.
 - **Controls**: Use **▶ Start/Pause** for automatic time progression or **⏭ Step** for tick-by-tick debugging.
 
 ### 3. Managing Processes
+
 - **Add Process**: Creates a new process container with an initial thread.
 - **Add Thread**: In the left sidebar, click the process name to add more threads to it.
 - **Kill Process**: Instantly terminates all threads within that process.
 
 ### 4. Reading the Visuals
+
 - **Gantt Chart**: Located in the first tab on the right; provides a timeline of execution.
 - **Sync Panel**: Watch for the lock icon to see which thread currently holds a semaphore.
 - **Cores**: Observe the green bars to see real-time execution progress on the selected cores.
@@ -116,9 +125,11 @@ Below is a short guide to every file in the repository and its role in the syste
 ---
 
 ## ROADMAP: FUTURE VERSIONS
+
 - **Stand-alone Windows EXE**: We are currently developing a full-fledged Windows application version.
 - **Native Installer**: Future releases will include a professional `.exe` installer (using `jpackage`), which wil bundle its own Java Runtime—no manual setup required.
 - **Cross-Platform Bundles**: Standalone packages for Linux and macOS.
 
 ---
+
 **Ownership**: Tharun (ktk-007) | **GitHub**: https://github.com/ktk-007/os-thread-simulator


### PR DESCRIPTION
## What changed
- Fixed a typo in the README.md file map table
- `Repesents` → `Represents` in KernelThread.java description

## Type of change
- [x] Bug fix / typo fix (documentation)

## Checklist
- [x] I have read the README
- [x] My change is limited to the described fix