### PR TITLE
Add CSV export support for simulation results #23

### DIFF
--- a/src/com/ossim/ui/MainWindow.java
+++ b/src/com/ossim/ui/MainWindow.java
@@ -1,14 +1,17 @@
 package com.ossim.ui;
 
 import com.ossim.model.MoveEvent;
+import com.ossim.model.SimThread;
 import com.ossim.scheduler.SimEngine;
 import com.ossim.ui.panels.*;
-
-import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
-import java.util.List;
+import java.util.*;
+import javax.swing.*;
+
+
+
 
 public class MainWindow extends JFrame {
 
@@ -25,15 +28,15 @@ public class MainWindow extends JFrame {
     private JSplitPane      mainSplit;
     private JSplitPane      leftSplit;
 
-    private Timer autoTimer;
+    private javax.swing.Timer autoTimer;
 
-    // Slower tick: 1000ms auto, 800ms step animation
+    
     private static final int AUTO_DELAY = 1000;
 
     public MainWindow() {
         super("RTOS ThreadVision (Thread Simulator)");
         UIUtils.applyDarkLook();
-        setUndecorated(true);           // remove OS native title bar
+        setUndecorated(true);          
         setDefaultCloseOperation(EXIT_ON_CLOSE);
         setSize(1460, 900);
         setMinimumSize(new Dimension(1240, 700));
@@ -47,28 +50,28 @@ public class MainWindow extends JFrame {
     private void build() {
         setLayout(new BorderLayout());
 
-        // ---- CUSTOM TITLE BAR ----
+       
         CustomTitleBar titleBar = new CustomTitleBar(this);
 
-        // ---- CONFIG BAR ----
+     
         topBar = new TopBarPanel(engine, new TopBarPanel.TopBarListener() {
             @Override public void onStart()         { handleStartPause(); }
             @Override public void onStep()          { doStep(); }
             @Override public void onConfigChanged() { refresh(); }
         });
 
-        // Stack title bar + config bar in a single NORTH wrapper
+       
         JPanel northWrapper = new JPanel(new BorderLayout());
         northWrapper.setBackground(Theme.BG);
         northWrapper.add(titleBar, BorderLayout.NORTH);
         northWrapper.add(topBar,   BorderLayout.CENTER);
         add(northWrapper, BorderLayout.NORTH);
 
-        // ---- STATUS BAR ----
+       
         statusBar = new StatusBar(engine);
         add(statusBar, BorderLayout.SOUTH);
 
-        // ---- LEFT PANEL ----
+       
         processPanel = new ProcessPanel(engine);
         processPanel.setListener(new ProcessPanel.ProcessPanelListener() {
             @Override public void onAddProcess()          { engine.addProcess(); refresh(); }
@@ -92,12 +95,12 @@ public class MainWindow extends JFrame {
         syncAndCores.add(coresPanel, BorderLayout.CENTER);
         centerPanel.add(syncAndCores, BorderLayout.CENTER);
 
-        // ---- RIGHT PANEL (wider) ----
+        
         rightTables = new RightTablesPanel(engine);
         rightTables.setMinimumSize(new Dimension(300, 0));
         rightTables.setPreferredSize(new Dimension(500, 0));
 
-        // ---- SPLITS ----
+        
         leftSplit = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, processPanel, centerPanel);
         leftSplit.setDividerSize(4);
         leftSplit.setDividerLocation(250);
@@ -122,13 +125,13 @@ public class MainWindow extends JFrame {
             }
         });
 
-        // ---- AUTO TIMER (slower) ----
-        autoTimer = new Timer(AUTO_DELAY, e -> doStep());
+        
+        autoTimer = new javax.swing.Timer(AUTO_DELAY, e -> doStep());
         autoTimer.setRepeats(true);
 
-        // ---- ENGINE LISTENER ----
+        
         engine.setListener(new SimEngine.SimListener() {
-            @Override public void onTick(int clock, List<MoveEvent> events) {
+            @Override public void onTick(int clock, java.util.List<MoveEvent> events) {
                 SwingUtilities.invokeLater(() -> {
                     movementBar.addEvents(events);
                     refresh();
@@ -140,17 +143,62 @@ public class MainWindow extends JFrame {
                         autoTimer.stop();
                         topBar.resetStartState();
                     }
+
+
+                    
+                    java.util.List<MoveEvent> moveHistory = new ArrayList<>(engine.getMoveHistory());
+                    Map<String, String> finalCoreIds = extractFinalCoreIds(engine);
+                    topBar.setExportSnapshot(moveHistory, finalCoreIds, engine);
+                    topBar.getExportButton().setEnabled(true);
                     JOptionPane.showMessageDialog(MainWindow.this,
                         "<html><b>Simulation Complete</b><br>All threads have finished execution.<br>Clock: "
                             + engine.getClock() + " ticks</html>",
                         "Simulation Complete", JOptionPane.INFORMATION_MESSAGE);
                 });
             }
+
+
+            
+            private Map<String, String> extractFinalCoreIds(SimEngine engine) {
+                Map<String, String> finalCores = new HashMap<>();
+                
+                for (SimThread t : engine.allThreads()) {
+                    String core = String.valueOf(t.getAssignedCore());
+                    finalCores.put(t.getTid(), core != null ? core : "");
+                }
+
+
+                
+                
+                java.util.List<MoveEvent> history = engine.getMoveHistory();
+                if (history != null && !history.isEmpty()) {
+                    java.util.Set<String> knownStates = new java.util.HashSet<>(java.util.Arrays.asList(
+                        "Ready", "Running", "Waiting", "Blocked", "Done", "Created", "Terminated"
+                    ));
+                    
+                    for (MoveEvent event : history) {
+                        String tid = event.tid;
+                        if ((finalCores.get(tid) == null || finalCores.get(tid).isEmpty())) {
+                            
+                            if (!knownStates.contains(event.to) && event.to != null && !event.to.isEmpty()) {
+                                finalCores.put(tid, event.to);
+                            }
+                           
+                            else if (!knownStates.contains(event.from) && event.from != null && !event.from.isEmpty()) {
+                                finalCores.put(tid, event.from);
+                            }
+                        }
+                    }
+                }
+                
+                return finalCores;
+            }
         });
     }
 
     private void handleStartPause() {
         if (topBar.isStarted()) {
+            topBar.getExportButton().setEnabled(false);
             autoTimer.start();
         } else {
             autoTimer.stop();
@@ -159,12 +207,12 @@ public class MainWindow extends JFrame {
 
     private void doStep() {
         engine.tick();
-        // Engine listener calls refresh via onTick
     }
 
     private void doReset() {
         autoTimer.stop();
         movementBar.clear();
+        topBar.getExportButton().setEnabled(false);
         engine.init();
         refresh();
     }

--- a/src/com/ossim/ui/Theme.java
+++ b/src/com/ossim/ui/Theme.java
@@ -33,6 +33,9 @@ public class Theme {
         return new Color(c.getRed(), c.getGreen(), c.getBlue(), Math.max(0, Math.min(255, alpha)));
     }
 
+
+    
+
     public static Color statusColor(String status) {
         if (status == null) return TEXT2;
         switch (status.toUpperCase()) {

--- a/src/com/ossim/ui/panels/StatusBar.java
+++ b/src/com/ossim/ui/panels/StatusBar.java
@@ -3,10 +3,13 @@ package com.ossim.ui.panels;
 import com.ossim.model.ThreadStatus;
 import com.ossim.scheduler.SimEngine;
 import com.ossim.ui.Theme;
-
+import java.awt.*;
 import javax.swing.*;
 import javax.swing.border.*;
-import java.awt.*;
+
+
+
+
 
 public class StatusBar extends JPanel {
 
@@ -68,6 +71,9 @@ public class StatusBar extends JPanel {
         tickTimer.setRepeats(false);
     }
 
+
+
+
     public void refresh() {
         var all = engine.allThreads();
         clockLabel.setText(String.valueOf(engine.getClock()));
@@ -83,6 +89,10 @@ public class StatusBar extends JPanel {
         tickDot.repaint();
         tickTimer.restart();
     }
+
+
+
+    
 
     private JPanel statItem(String labelText, JLabel val) {
         JPanel p = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));

--- a/src/com/ossim/ui/panels/TopBarPanel.java
+++ b/src/com/ossim/ui/panels/TopBarPanel.java
@@ -4,10 +4,11 @@ import com.ossim.model.*;
 import com.ossim.scheduler.SimEngine;
 import com.ossim.ui.Theme;
 import com.ossim.ui.UIUtils;
-
-import javax.swing.*;
-import javax.swing.border.EmptyBorder;
+import com.ossim.util.SimulationExporter;
 import java.awt.*;
+import java.io.File;
+import java.util.*;
+import javax.swing.*;
 
 public class TopBarPanel extends JPanel {
 
@@ -28,16 +29,20 @@ public class TopBarPanel extends JPanel {
     private JLabel tqLabel, tqSpin, burstLabel, burstSpin;
     public  UIUtils.OutlinedButton startBtn;
     public  UIUtils.OutlinedButton stepBtn;
+    public  UIUtils.OutlinedButton exportBtn;
     private boolean started = false;
+
+    private java.util.List<MoveEvent> snapshotMoveHistory;
+    private Map<String, String> snapshotFinalCoreIds;
+    private SimEngine snapshotEngine;
 
     public TopBarPanel(SimEngine engine, TopBarListener listener) {
         this.engine   = engine;
         this.listener = listener;
         setBackground(Theme.BG2);
         setBorder(BorderFactory.createMatteBorder(0, 0, 2, 0, Theme.BORDER));
-        // Fixed height removed to prevent cutoff
         setLayout(new BorderLayout());
-        setBorder(BorderFactory.createEmptyBorder(6, 10, 6, 10)); // Add some padding
+        setBorder(BorderFactory.createEmptyBorder(6, 10, 6, 10));
         build();
     }
 
@@ -45,7 +50,7 @@ public class TopBarPanel extends JPanel {
         JPanel left = new JPanel(new FlowLayout(FlowLayout.LEFT, 12, 10));
         left.setOpaque(false);
 
-        // Thread model
+       
         left.add(lbl("Thread model:"));
         threadModelCombo = UIUtils.darkCombo(new String[]{"One-One", "Many-One", "Many-Many"});
         threadModelCombo.setPreferredSize(new Dimension(115, 28));
@@ -54,7 +59,6 @@ public class TopBarPanel extends JPanel {
 
         sep(left);
 
-        // Scheduling
         left.add(lbl("Scheduling:"));
         algoCombo = UIUtils.darkCombo(new String[]{"FCFS", "Round Robin", "SJF", "Priority"});
         algoCombo.setSelectedIndex(1);
@@ -64,7 +68,7 @@ public class TopBarPanel extends JPanel {
 
         sep(left);
 
-        // Config mode
+     
         left.add(lbl("Config:"));
         autoBtn   = radio("Auto",   true);
         manualBtn = radio("Manual", false);
@@ -75,7 +79,6 @@ public class TopBarPanel extends JPanel {
 
         sep(left);
 
-        // Sync model
         left.add(lbl("Sync:"));
         semBtn = radio("Semaphores", true);
         monBtn = radio("Monitors",   false);
@@ -86,7 +89,6 @@ public class TopBarPanel extends JPanel {
 
         sep(left);
 
-        // Cores
         left.add(lbl("CPU Cores:"));
         coreSpinner = UIUtils.darkSpinner(4, 1, 16);
         coreSpinner.setPreferredSize(new Dimension(62, 28));
@@ -95,7 +97,7 @@ public class TopBarPanel extends JPanel {
 
         sep(left);
 
-        // Time quantum
+       
         tqLabel = lbl("Time Quantum:");
         left.add(tqLabel);
         tqSpinner = UIUtils.darkSpinner(3, 1, 20);
@@ -103,7 +105,7 @@ public class TopBarPanel extends JPanel {
         tqSpinner.addChangeListener(e -> applyConfig());
         left.add(tqSpinner);
 
-        // Burst (manual mode only)
+        
         burstLabel = lbl("Burst Time:");
         left.add(burstLabel);
         burstSpinner = UIUtils.darkSpinner(5, 1, 30);
@@ -111,7 +113,7 @@ public class TopBarPanel extends JPanel {
         burstSpinner.addChangeListener(e -> applyConfig());
         left.add(burstSpinner);
 
-        // Action buttons (right-aligned)
+        
         JPanel right = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 10));
         right.setOpaque(false);
 
@@ -122,8 +124,14 @@ public class TopBarPanel extends JPanel {
 
         stepBtn = UIUtils.makeButton("Step", Theme.BORDER2, Theme.TEXT);
         stepBtn.setPreferredSize(new Dimension(80, 34));
-        stepBtn.addActionListener(e -> listener.onStep());
+        stepBtn.addActionListener(e -> { if (listener != null) listener.onStep(); });
         right.add(stepBtn);
+
+        exportBtn = UIUtils.makeButton("Export", Theme.GREEN, Theme.GREEN);
+        exportBtn.setPreferredSize(new Dimension(80, 34));
+        exportBtn.setEnabled(false);
+        exportBtn.addActionListener(e -> handleExportClick());
+        right.add(exportBtn);
 
         add(left, BorderLayout.CENTER);
         add(right, BorderLayout.EAST);
@@ -207,5 +215,62 @@ public class TopBarPanel extends JPanel {
         s.setPreferredSize(new Dimension(1, 24));
         s.setForeground(Theme.BORDER2);
         into.add(s);
+    }
+
+    
+    public void setExportSnapshot(java.util.List<MoveEvent> moveHistory, Map<String, String> finalCoreIds, SimEngine engine) {
+        this.snapshotMoveHistory = moveHistory;
+        this.snapshotFinalCoreIds = finalCoreIds;
+        this.snapshotEngine = engine;
+    }
+
+    
+    private void handleExportClick() {
+        JFileChooser chooser = new JFileChooser();
+        chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+        chooser.setDialogTitle("Save Simulation Results as CSV");
+
+        String defaultName = generateDefaultFilename();
+        chooser.setSelectedFile(new File(defaultName));
+
+        int returnVal = chooser.showSaveDialog(this);
+        if (returnVal == JFileChooser.APPROVE_OPTION) {
+            File selectedFile = chooser.getSelectedFile();
+            
+            
+            String filename = selectedFile.getAbsolutePath();
+            if (!filename.toLowerCase().endsWith(".csv")) {
+                filename += ".csv";
+                selectedFile = new File(filename);
+            }
+
+           
+            boolean success = SimulationExporter.exportToCSV(
+                snapshotEngine, selectedFile, snapshotMoveHistory, snapshotFinalCoreIds);
+
+            if (success) {
+                JOptionPane.showMessageDialog(this,
+                    "<html><b>Export Successful!</b><br>CSV file saved to:<br>" + 
+                    selectedFile.getAbsolutePath() + "</html>",
+                    "Export Complete", JOptionPane.INFORMATION_MESSAGE);
+            } else {
+                JOptionPane.showMessageDialog(this,
+                    "<html><b>Export Failed!</b><br>Check file permissions and disk space.</html>",
+                    "Export Error", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    
+    private String generateDefaultFilename() {
+        java.time.LocalDateTime now = java.time.LocalDateTime.now();
+        java.time.format.DateTimeFormatter formatter = 
+            java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
+        return "ossim_results_" + now.format(formatter) + ".csv";
+    }
+
+    
+    public JButton getExportButton() {
+        return exportBtn;
     }
 }

--- a/src/com/ossim/util/SimulationExporter.java
+++ b/src/com/ossim/util/SimulationExporter.java
@@ -1,0 +1,320 @@
+package com.ossim.util;
+
+import com.ossim.model.*;
+import com.ossim.scheduler.SimEngine;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.*;
+
+public class SimulationExporter {
+
+    // Extract final core assignments from SimThread state + MoveEvent history fallback
+    private static Map<String, String> extractFinalCoreIds(java.util.List<MoveEvent> moveHistory, SimEngine engine) {
+        Map<String, String> finalCores = new HashMap<>();
+        
+        // PRIORITY 1: Read getAssignedCore() directly from SimThread objects
+        // (This is captured at onFinished time before engine clears state)
+        for (SimThread t : engine.allThreads()) {
+            int coreNum = t.getAssignedCore();
+            String coreStr = (coreNum >= 0) ? ("Core-" + coreNum) : "";
+            finalCores.put(t.getTid(), coreStr);
+        }
+        
+        // PRIORITY 2: If any thread still has empty core ID, try MoveEvent history
+        if (moveHistory != null && !moveHistory.isEmpty()) {
+            // Known state strings to exclude
+            java.util.Set<String> knownStates = new java.util.HashSet<>(java.util.Arrays.asList(
+                "Ready", "Running", "Waiting", "Blocked", "Done", "Created", "Terminated"
+            ));
+            
+            
+            for (MoveEvent event : moveHistory) {
+                String tid = event.tid;
+                if ((finalCores.get(tid) == null || finalCores.get(tid).isEmpty())) {
+                   
+                    if (!knownStates.contains(event.to) && event.to != null && !event.to.isEmpty()) {
+                        finalCores.put(tid, event.to);
+                    }
+                   
+                    else if (!knownStates.contains(event.from) && event.from != null && !event.from.isEmpty()) {
+                        finalCores.put(tid, event.from);
+                    }
+                }
+            }
+        }
+        
+        return finalCores;
+    }
+
+    /**
+     * Export simulation data to CSV with 5 sections
+     * 
+     * @param engine The simulation engine
+     * @param outputFile The CSV output file
+     * @param moveHistory Snapshotted MoveEvent history
+     * @param finalCoreIds Snapshotted core ID assignments
+     * @return true if export succeeded, false on error
+     */
+    public static boolean exportToCSV(SimEngine engine, File outputFile, 
+            java.util.List<MoveEvent> moveHistory, Map<String, String> finalCoreIds) {
+        try {
+            try (PrintWriter writer = new PrintWriter(outputFile)) {
+                java.util.List<MoveEvent> historyToUse = (moveHistory != null && !moveHistory.isEmpty()) 
+                    ? moveHistory : engine.getMoveHistory();
+                Map<String, String> coreIdsToUse = (finalCoreIds != null && !finalCoreIds.isEmpty()) 
+                    ? finalCoreIds : extractFinalCoreIds(historyToUse, engine);
+                
+                // Write all 5 sections to single file
+                writeThreadDetails(writer, engine);
+                writer.println();
+                
+                writeTimingStatistics(writer, engine);
+                writer.println();
+                
+                writeThreadStatus(writer, engine, coreIdsToUse);
+                writer.println();
+                
+                writeKernelThreadMap(writer, engine);
+                writer.println();
+                
+                writeGanttChart(writer, engine, historyToUse);
+            }
+
+            return true;
+        } catch (IOException e) {
+            System.err.println("Export failed: " + e.getMessage());
+            return false;
+        }
+    }
+
+
+
+    /**
+     * SECTION 1: Thread Details
+     * BUG FIX #1: Only show priority for PRIORITY algorithm, show "-" otherwise
+     */
+    private static void writeThreadDetails(PrintWriter writer, SimEngine engine) {
+        writer.println("===== SECTION 1: THREAD DETAILS =====");
+        writer.println("PID,TID,Algorithm,BurstTime,TimeQuantum,Priority,Memory_MB");
+        
+        for (SimThread t : engine.allThreads()) {
+            String algo = algoShortName(t.getAlgo());
+            int quantum = (t.getAlgo() == SchedulingAlgo.ROUND_ROBIN) ? 
+                engine.getTimeQuantum() : 0;
+            
+            // BUG FIX #1: Only show priority if using PRIORITY algorithm
+            String priority = (t.getAlgo() == SchedulingAlgo.PRIORITY) ? 
+                String.valueOf(t.getPriority()) : "—";
+            
+            writer.println(escapeCsvValue(t.getPid()) + "," +
+                escapeCsvValue(t.getTid()) + "," +
+                algo + "," +
+                t.getBurstTime() + "," +
+                quantum + "," +
+                priority + "," +
+                t.getMemoryMB());
+        }
+    }
+
+    /**
+     * SECTION 2: Timing Statistics
+     * FIXES: 
+     * - CompletionTick = final clock value when thread finishes
+     * - Derive TurnaroundTime = CompletionTick - ArrivalTime
+     * - Derive WaitTime = TurnaroundTime - BurstTime
+     */
+    private static void writeTimingStatistics(PrintWriter writer, SimEngine engine) {
+        writer.println("===== SECTION 2: TIMING STATISTICS =====");
+        writer.println("TID,ArrivalTime,WaitTime,TurnaroundTime,CompletionTick");
+        
+        for (SimThread t : engine.allThreads()) {
+            int arrival = t.getStartTick() >= 0 ? t.getStartTick() : 0;
+            // CompletionTick is when thread became DONE (finishTick + 1)
+            int completion = t.getFinishTick() >= 0 ? (t.getFinishTick() + 1) : 0;
+            
+            // DERIVE from ticks, don't read from SimThread fields
+            int tat = completion - arrival;  // TurnaroundTime
+            int wait = tat - t.getBurstTime();  // WaitTime
+            
+            writer.println(escapeCsvValue(t.getTid()) + "," +
+                arrival + "," +
+                wait + "," +
+                tat + "," +
+                completion);
+        }
+    }
+
+    /**
+     * SECTION 3: Thread Status
+     * BUG FIX #3: Use final core assignments from MoveEvent history instead of current state
+     */
+    private static void writeThreadStatus(PrintWriter writer, SimEngine engine, Map<String, String> finalCoreId) {
+        writer.println("===== SECTION 3: THREAD STATUS =====");
+        writer.println("TID,FinalStatus,CoreID,KernelThreadID");
+        
+        for (SimThread t : engine.allThreads()) {
+            String status = t.getStatus().getLabel();
+            
+            // BUG FIX #3: Use extracted final core ID from history, not current state
+            String coreId = finalCoreId.getOrDefault(t.getTid(), "");
+            if (coreId.isEmpty()) {
+                coreId = "—";
+            } else if (coreId.matches("\\d+")) {
+                // If it's just a number (e.g., "0"), format as "Core-X"
+                coreId = "Core-" + coreId;
+            }
+            
+            String kthreadId = !t.getKthreadId().isEmpty() ? t.getKthreadId() : "—";
+            
+            writer.println(escapeCsvValue(t.getTid()) + "," +
+                escapeCsvValue(status) + "," +
+                coreId + "," +
+                kthreadId);
+        }
+    }
+
+    /**
+     * SECTION 4: Kernel Thread Map
+     */
+    private static void writeKernelThreadMap(PrintWriter writer, SimEngine engine) {
+        writer.println("===== SECTION 4: KERNEL THREAD MAP =====");
+        writer.println("UserThreadID,KernelThreadID,ThreadModel");
+        
+        String threadModel = engine.getThreadModel().toString();
+        
+        for (SimThread t : engine.allThreads()) {
+            String kthreadId = !t.getKthreadId().isEmpty() ? t.getKthreadId() : "—";
+            
+            writer.println(escapeCsvValue(t.getTid()) + "," +
+                kthreadId + "," +
+                threadModel);
+        }
+    }
+
+    /**
+     * SECTION 5: Gantt Chart (execution timeline with RR slices)
+     * Use snapshotted MoveEvent history to show individual RR slices
+     * Fallback: Use SimThread start/finish ticks if history is unavailable
+     */
+    private static void writeGanttChart(PrintWriter writer, SimEngine engine, java.util.List<MoveEvent> moveHistory) {
+        writer.println("===== SECTION 5: GANTT CHART =====");
+        writer.println("TID,StartTick,EndTick,CoreID");
+        
+        boolean wroteData = false;
+        
+        // Try to parse move history first
+        if (moveHistory != null && !moveHistory.isEmpty()) {
+            Map<String, java.util.List<GanttSlice>> slices = extractGanttSlices(moveHistory);
+            for (String tid : slices.keySet()) {
+                for (GanttSlice slice : slices.get(tid)) {
+                    writer.println(escapeCsvValue(tid) + "," +
+                        slice.startTick + "," +
+                        slice.endTick + "," +
+                        slice.coreId);
+                    wroteData = true;
+                }
+            }
+        }
+        
+        // FALLBACK: If no data was written from history, use SimThread start/finish ticks
+        if (!wroteData) {
+            for (SimThread t : engine.allThreads()) {
+                int start = t.getStartTick();
+                int finish = t.getFinishTick();
+                if (start >= 0 && finish >= 0) {
+                    // Format core as "Core-X"
+                    int coreNum = t.getAssignedCore();
+                    String coreId = (coreNum >= 0) ? ("Core-" + coreNum) : "—";
+                    
+                    writer.println(escapeCsvValue(t.getTid()) + "," +
+                        start + "," +
+                        (finish + 1) + "," +
+                        coreId);
+                    wroteData = true;
+                }
+            }
+        }
+    }
+
+    
+    private static Map<String, java.util.List<GanttSlice>> extractGanttSlices(java.util.List<MoveEvent> moveHistory) {
+        Map<String, java.util.List<GanttSlice>> slices = new HashMap<>();
+        Map<String, Integer> sliceStart = new HashMap<>();  // Track when thread entered a core
+        Map<String, String> sliceCore = new HashMap<>();    // Track which core thread is on
+        
+        for (MoveEvent event : moveHistory) {
+            String tid = event.tid;
+            
+            slices.putIfAbsent(tid, new ArrayList<>());
+            
+            // Check if thread is entering a core (transition to "Core-X")
+            if (event.to.startsWith("Core-")) {
+                // Close any previous incomplete slice
+                if (sliceStart.containsKey(tid)) {
+                    int startTick = sliceStart.get(tid);
+                    int endTick = event.tick;
+                    String coreId = sliceCore.get(tid);
+                    slices.get(tid).add(new GanttSlice(startTick, endTick, coreId));
+                }
+                // Start new slice
+                sliceStart.put(tid, event.tick);
+                sliceCore.put(tid, event.to);
+            }
+            // Check if thread is leaving a core (transition from Core-X to Ready/Waiting/Done)
+            else if (event.from.startsWith("Core-") && sliceStart.containsKey(tid)) {
+                int startTick = sliceStart.get(tid);
+                int endTick = event.tick;
+                String coreId = event.from;
+                
+                slices.get(tid).add(new GanttSlice(startTick, endTick, coreId));
+                sliceStart.remove(tid);
+                sliceCore.remove(tid);
+            }
+        }
+        
+        return slices;
+    }
+
+    /**
+     * Helper class for Gantt slices
+     */
+    private static class GanttSlice {
+        int startTick;
+        int endTick;
+        String coreId;
+        
+        GanttSlice(int startTick, int endTick, String coreId) {
+            this.startTick = startTick;
+            this.endTick = endTick;
+            this.coreId = coreId;
+        }
+    }
+
+    /**
+     * Escape CSV values: wrap in quotes if contains comma/quote/newline, double-escape quotes
+     */
+    private static String escapeCsvValue(String value) {
+        if (value == null) return "";
+        
+        // If value contains comma, quote, or newline, wrap in quotes and escape internal quotes
+        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    /**
+     * Convert algorithm enum to short name for CSV
+     */
+    private static String algoShortName(SchedulingAlgo algo) {
+        switch (algo) {
+            case FCFS:         return "FCFS";
+            case ROUND_ROBIN:  return "RR";
+            case SJF:          return "SJF";
+            case PRIORITY:     return "Pri";
+            default:           return algo.toString();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a CSV export feature for the OS Thread Simulator.
<img width="1917" height="139" alt="image" src="https://github.com/user-attachments/assets/ed29b260-02a2-4906-ab4e-27546871a045" />


Changes
Added an Export button to the top toolbar
Added support for exporting simulation results into a single structured CSV file
Export includes:
Thread Details
Timing Statistics
Thread Status
Kernel Thread Map
Gantt Chart
Added snapshot handling to preserve simulation data after completion
Added CSV-safe formatting and fallback handling for missing values
Fixed timing calculations for completion, turnaround, and wait times
Files Modified
```
src/com/ossim/util/SimulationExporter.java (new)
src/com/ossim/ui/panels/TopBarPanel.java
src/com/ossim/ui/MainWindow.java
```
Testing
Tested with multiple simulations and thread counts
Verified exported CSV data against UI results
No compilation errors