### PR TITLE
Feature: Add dynamic color picker for threads

### DIFF
--- a/src/com/ossim/model/SimThread.java
+++ b/src/com/ossim/model/SimThread.java
@@ -7,7 +7,7 @@ public class SimThread {
 
     private final String tid;
     private final String pid;
-    private final Color color;
+    private Color color;
 
     private int burstTime;
     private int remainingTime;
@@ -50,6 +50,7 @@ public class SimThread {
     public String getTid() { return tid; }
     public String getPid() { return pid; }
     public Color getColor() { return color; }
+    public void setColor(Color color) { this.color = color; }
     public int getBurstTime() { return burstTime; }
     public int getRemainingTime() { return remainingTime; }
     public int getPriority() { return priority; }

--- a/src/com/ossim/ui/MainWindow.java
+++ b/src/com/ossim/ui/MainWindow.java
@@ -75,6 +75,7 @@ public class MainWindow extends JFrame {
             @Override public void onAddThread(String pid) { engine.addThread(pid); refresh(); }
             @Override public void onTerminate(String pid) { engine.terminateProcess(pid); refresh(); }
             @Override public void onReset()               { doReset(); }
+            @Override public void onColorChanged()        { refresh(); }
         });
 
         // ---- CENTER ----

--- a/src/com/ossim/ui/panels/ProcessPanel.java
+++ b/src/com/ossim/ui/panels/ProcessPanel.java
@@ -17,6 +17,7 @@ public class ProcessPanel extends JPanel {
         void onAddThread(String pid);
         void onTerminate(String pid);
         void onReset();
+        void onColorChanged();
     }
 
     private final SimEngine engine;
@@ -132,6 +133,9 @@ public class ProcessPanel extends JPanel {
         JPanel threadArea = new JPanel(new FlowLayout(FlowLayout.LEFT, 3, 3));
         threadArea.setBackground(Theme.BG2);
         for (SimThread t : proc.getThreads()) {
+            JPanel tBox = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+            tBox.setOpaque(false);
+
             String st = threadStatusAbbrev(t.getStatus());
             Color fg = Theme.statusColor(t.getStatus().getLabel());
             JLabel pill = new JLabel(t.getTid() + " " + st);
@@ -140,7 +144,34 @@ public class ProcessPanel extends JPanel {
             pill.setOpaque(true);
             pill.setBackground(Theme.withAlpha(fg, 30));
             pill.setBorder(new EmptyBorder(2, 5, 2, 5));
-            threadArea.add(pill);
+            tBox.add(pill);
+
+            JPanel spacer = new JPanel();
+            spacer.setOpaque(false);
+            spacer.setPreferredSize(new Dimension(2, 12));
+            tBox.add(spacer);
+
+            JButton colBtn = new JButton();
+            colBtn.setPreferredSize(new Dimension(14, 14));
+            colBtn.setBackground(t.getColor());
+            colBtn.setBorder(BorderFactory.createLineBorder(Theme.BORDER));
+            colBtn.setCursor(new Cursor(Cursor.HAND_CURSOR));
+            colBtn.setToolTipText("Change color for " + t.getTid());
+            colBtn.addActionListener(e -> {
+                Color c = JColorChooser.showDialog(ProcessPanel.this, "Choose Color for " + t.getTid(), t.getColor());
+                if (c != null) {
+                    t.setColor(c);
+                    if (listener != null) listener.onColorChanged();
+                }
+            });
+            tBox.add(colBtn);
+
+            JPanel pillWrapper = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+            pillWrapper.setOpaque(false);
+            pillWrapper.add(tBox);
+            pillWrapper.setBorder(new EmptyBorder(0, 0, 0, 4));
+
+            threadArea.add(pillWrapper);
         }
         panel.add(threadArea, BorderLayout.CENTER);
 


### PR DESCRIPTION
### Description
This PR resolves the issue where threads get visually similar random colors that users cannot change, causing confusion on the Gantt chart.

### Changes Made:
- **`model/SimThread.java`**: Made `color` mutable and added a setter.
- **`ui/panels/ProcessPanel.java`**: Added a small color picker button next to each thread pill. Clicking it opens a `JColorChooser` dialog.
- **`ui/MainWindow.java`**: Added an `onColorChanged` listener to instantly trigger a global `refresh()`. 

The chosen color now immediately reflects across the Gantt chart, CPU Cores panel, and Status tables without needing to wait for the next simulation tick.
